### PR TITLE
Fix request body for ApplyAdvancedGameSettings

### DIFF
--- a/openapi/components/schemas/advancedGameSettings.yml
+++ b/openapi/components/schemas/advancedGameSettings.yml
@@ -1,10 +1,6 @@
 type: object
 properties:
-  creativeModeEnabled:
-    type: boolean
-    description: True if Advanced Game Settings are enabled for the currently loaded session
-    example: false
-  advancedGameSettings:
+  appliedAdvancedGameSettings:
     type: object
     description: Values of Advanced Game Settings. Key is the name of the setting, and value is its stringified value
     additionalProperties:
@@ -22,5 +18,4 @@ properties:
       FG.PlayerRules.GodMode: "False"
       FG.PlayerRules.FlightMode: "False"
 required:
-- creativeModeEnabled
-- advancedGameSettings
+- appliedAdvancedGameSettings


### PR DESCRIPTION
Remove `creativeModeEnabled` from the request body as it's not supposed to be passed to the ApplyAdvancedGameSettings function, it's only returned as response from the GetAdvancedGameSettings function.

Rename `advancedGameSettings` to `appliedAdvancedGameSettings` because that is what ApplyAdvancedGameSettings expects, which isn't really intuitive but that's what it wants.