### PR TITLE
Organize operations into tags & Tweak ReDocly display settings

### DIFF
--- a/openapi/functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
+++ b/openapi/functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
@@ -3,6 +3,8 @@ post:
   operationId: ApplyAdvancedGameSettings
   description: |
     Applies new values to the provided Advanced Game Settings properties. Will automatically enable Advanced Game Settings for the currently loaded save if they are not enabled already.
+  tags:
+  - Game Settings
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
+++ b/openapi/functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Applies new values to the provided Advanced Game Settings properties. Will automatically enable Advanced Game Settings for the currently loaded save if they are not enabled already.
   tags:
-  - Game Settings
+  - Game
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/applyServerOptions/applyServerOptions.yml
+++ b/openapi/functions/applyServerOptions/applyServerOptions.yml
@@ -3,6 +3,8 @@ post:
   operationId: ApplyServerOptions
   description: |
     Applies new Server Options to the Dedicated Server. Requires Admin privileges.
+  tags:
+  - Server Options
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/applyServerOptions/applyServerOptions.yml
+++ b/openapi/functions/applyServerOptions/applyServerOptions.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Applies new Server Options to the Dedicated Server. Requires Admin privileges.
   tags:
-  - Server Options
+  - Server
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/claimServer/claimServer.yml
+++ b/openapi/functions/claimServer/claimServer.yml
@@ -5,6 +5,7 @@ post:
     Claims this Dedicated Server if it is not claimed. Requires InitialAdmin privilege level, which can only be acquired by attempting passwordless login while the server does not have an Admin Password set, e.g. it is not claimed yet. Function does not return any data in case of success, and the server is claimed. The client should drop InitialAdmin privileges after that and use returned AuthenticationToken instead, and update it's cached server game state by calling QueryServerState.
   tags:
   - Setup
+  - Server
   security:
   - bearerAuth: ['InitialAdmin']
   requestBody:

--- a/openapi/functions/claimServer/claimServer.yml
+++ b/openapi/functions/claimServer/claimServer.yml
@@ -3,6 +3,8 @@ post:
   operationId: ClaimServer
   description: |
     Claims this Dedicated Server if it is not claimed. Requires InitialAdmin privilege level, which can only be acquired by attempting passwordless login while the server does not have an Admin Password set, e.g. it is not claimed yet. Function does not return any data in case of success, and the server is claimed. The client should drop InitialAdmin privileges after that and use returned AuthenticationToken instead, and update it's cached server game state by calling QueryServerState.
+  tags:
+  - Setup
   security:
   - bearerAuth: ['InitialAdmin']
   requestBody:

--- a/openapi/functions/createNewGame/createNewGame.yml
+++ b/openapi/functions/createNewGame/createNewGame.yml
@@ -3,6 +3,8 @@ post:
   operationId: CreateNewGame
   description: |
     Creates a new session on the Dedicated Server, and immediately loads it. HTTPS API becomes temporarily unavailable when map loading is in progress | Function does not return any data on success.
+  tags:
+  - Setup
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/createNewGame/createNewGame.yml
+++ b/openapi/functions/createNewGame/createNewGame.yml
@@ -5,6 +5,7 @@ post:
     Creates a new session on the Dedicated Server, and immediately loads it. HTTPS API becomes temporarily unavailable when map loading is in progress | Function does not return any data on success.
   tags:
   - Setup
+  - Game
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/deleteSaveFile/deleteSaveFile.yml
+++ b/openapi/functions/deleteSaveFile/deleteSaveFile.yml
@@ -3,6 +3,8 @@ post:
   operationId: DeleteSaveFile
   description: |
     Deletes the existing save game file from the server. Requires Admin privileges. SaveName might be changed to satisfy file system restrictions on file names. Function does not return any data on success.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/deleteSaveFile/deleteSaveFile.yml
+++ b/openapi/functions/deleteSaveFile/deleteSaveFile.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Deletes the existing save game file from the server. Requires Admin privileges. SaveName might be changed to satisfy file system restrictions on file names. Function does not return any data on success.
   tags:
-  - Save Management
+  - Saves
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/deleteSaveSession/deleteSaveSession.yml
+++ b/openapi/functions/deleteSaveSession/deleteSaveSession.yml
@@ -3,6 +3,8 @@ post:
   operationId: DeleteSaveSession
   description: |
     Deletes all save files belonging to the specific session name. Requires Admin privileges. SessionName must be a valid session name with at least one saved save game file belonging to it. Function does not return any data on success.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/deleteSaveSession/deleteSaveSession.yml
+++ b/openapi/functions/deleteSaveSession/deleteSaveSession.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Deletes all save files belonging to the specific session name. Requires Admin privileges. SessionName must be a valid session name with at least one saved save game file belonging to it. Function does not return any data on success.
   tags:
-  - Save Management
+  - Sessions
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/downloadSaveGame/downloadSaveGame.yml
+++ b/openapi/functions/downloadSaveGame/downloadSaveGame.yml
@@ -3,6 +3,8 @@ post:
   operationId: DownloadSaveGame
   description: |
     Downloads save game with the given name from the Dedicated Server. Requires Admin privileges. This function responds with the file attachment containing the save game file on success, and with normal error response in case of error.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/downloadSaveGame/downloadSaveGame.yml
+++ b/openapi/functions/downloadSaveGame/downloadSaveGame.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Downloads save game with the given name from the Dedicated Server. Requires Admin privileges. This function responds with the file attachment containing the save game file on success, and with normal error response in case of error.
   tags:
-  - Save Management
+  - Saves
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/enumerateSessions/enumerateSessions.yml
+++ b/openapi/functions/enumerateSessions/enumerateSessions.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Enumerates all save game files available on the Dedicated Server. Requires Admin privileges. Function does not require any additional parameters.
   tags:
-  - Save Management
+  - Sessions
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/enumerateSessions/enumerateSessions.yml
+++ b/openapi/functions/enumerateSessions/enumerateSessions.yml
@@ -3,6 +3,8 @@ post:
   operationId: EnumerateSessions
   description: |
     Enumerates all save game files available on the Dedicated Server. Requires Admin privileges. Function does not require any additional parameters.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/getAdvancedGameSettings/getAdvancedGameSettings.yml
+++ b/openapi/functions/getAdvancedGameSettings/getAdvancedGameSettings.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Retrieves currently applied advanced game settings. Does not require input parameters.
   tags:
-  - Game Settings
+  - Game
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/getAdvancedGameSettings/getAdvancedGameSettings.yml
+++ b/openapi/functions/getAdvancedGameSettings/getAdvancedGameSettings.yml
@@ -3,6 +3,8 @@ post:
   operationId: GetAdvancedGameSettings
   description: |
     Retrieves currently applied advanced game settings. Does not require input parameters.
+  tags:
+  - Game Settings
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/getServerOptions/getServerOptions.yml
+++ b/openapi/functions/getServerOptions/getServerOptions.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Retrieves currently applied server options and server options that are still pending application (because of needing session or server restart) Does not require input parameters.
   tags:
-  - Server Options
+  - Server
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/getServerOptions/getServerOptions.yml
+++ b/openapi/functions/getServerOptions/getServerOptions.yml
@@ -3,6 +3,8 @@ post:
   operationId: GetServerOptions
   description: |
     Retrieves currently applied server options and server options that are still pending application (because of needing session or server restart) Does not require input parameters.
+  tags:
+  - Server Options
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/healthCheck/healthCheck.yml
+++ b/openapi/functions/healthCheck/healthCheck.yml
@@ -2,6 +2,8 @@ post:
   summary: Health Check
   operationId: HealthCheck
   description: Performs a health check on the Dedicated Server API. Allows passing additional data between Modded Dedicated Server and Modded Game Client. This function requires no Authentication.
+  tags:
+  - Server Status
   security:
   - {}
   requestBody:

--- a/openapi/functions/healthCheck/healthCheck.yml
+++ b/openapi/functions/healthCheck/healthCheck.yml
@@ -3,7 +3,7 @@ post:
   operationId: HealthCheck
   description: Performs a health check on the Dedicated Server API. Allows passing additional data between Modded Dedicated Server and Modded Game Client. This function requires no Authentication.
   tags:
-  - Server Status
+  - Server
   security:
   - {}
   requestBody:

--- a/openapi/functions/loadGame/loadGame.yml
+++ b/openapi/functions/loadGame/loadGame.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Loads the save game file by name, optionally with Advanced Game Settings enabled. Requires Admin privileges. Dedicated Server HTTPS API will become temporarily unavailable when save game is being loaded. Function does not return any data on succcess.
   tags:
-  - Save Management
+  - Saves
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/loadGame/loadGame.yml
+++ b/openapi/functions/loadGame/loadGame.yml
@@ -3,6 +3,8 @@ post:
   operationId: LoadGame
   description: |
     Loads the save game file by name, optionally with Advanced Game Settings enabled. Requires Admin privileges. Dedicated Server HTTPS API will become temporarily unavailable when save game is being loaded. Function does not return any data on succcess.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/passwordLogin/passwordLogin.yml
+++ b/openapi/functions/passwordLogin/passwordLogin.yml
@@ -3,6 +3,8 @@ post:
   operationId: PasswordLogin
   description: |
     Attempts to log in to the Dedicated Server as a player using either Admin Password or Client Protection Password. This function requires no Authentication.
+  tags:
+  - Authorization
   security:
   - {}
   requestBody:

--- a/openapi/functions/passwordlessLogin/passwordlessLogin.yml
+++ b/openapi/functions/passwordlessLogin/passwordlessLogin.yml
@@ -3,6 +3,8 @@ post:
   operationId: PasswordlessLogin
   description: |
     Attempts to perform a passwordless login to the Dedicated Server as a player. Passwordless login is possible if the Dedicated Server is not claimed, or if Client Protection Password is not set for the Dedicated Server. This function requires no Authentication.
+  tags:
+  - Authorization
   security:
   - {}
   requestBody:

--- a/openapi/functions/queryServerState/queryServerState.yml
+++ b/openapi/functions/queryServerState/queryServerState.yml
@@ -3,6 +3,8 @@ post:
   operationId: QueryServerState
   description: |
     Retrieves the current state of the Dedicated Server. Does not require any input parameters.
+  tags:
+  - Server Status
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/queryServerState/queryServerState.yml
+++ b/openapi/functions/queryServerState/queryServerState.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Retrieves the current state of the Dedicated Server. Does not require any input parameters.
   tags:
-  - Server Status
+  - Server
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/functions/renameServer/renameServer.yml
+++ b/openapi/functions/renameServer/renameServer.yml
@@ -3,6 +3,8 @@ post:
   operationId: RenameServer
   description: |
     Renames the Dedicated Server once it has been claimed. Requires Admin privileges. Function does not return any data on success.
+  tags:
+  - Server Options
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/renameServer/renameServer.yml
+++ b/openapi/functions/renameServer/renameServer.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Renames the Dedicated Server once it has been claimed. Requires Admin privileges. Function does not return any data on success.
   tags:
-  - Server Options
+  - Server
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/runCommand/runCommand.yml
+++ b/openapi/functions/runCommand/runCommand.yml
@@ -3,6 +3,8 @@ post:
   operationId: RunCommand
   description: |
     Runs the given Console Command on the Dedicated Server, and returns it's output to the Console. Requires Admin privileges.
+  tags:
+  - Server Actions
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/runCommand/runCommand.yml
+++ b/openapi/functions/runCommand/runCommand.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Runs the given Console Command on the Dedicated Server, and returns it's output to the Console. Requires Admin privileges.
   tags:
-  - Server Actions
+  - Server
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/saveGame/saveGame.yml
+++ b/openapi/functions/saveGame/saveGame.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Saves the currently loaded session into the new save game file named as the argument. Requires Admin privileges. SaveName might be changed to satisfy file system restrictions on file names. Function does not return any data on success.
   tags:
-  - Save Management
+  - Saves
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/saveGame/saveGame.yml
+++ b/openapi/functions/saveGame/saveGame.yml
@@ -3,6 +3,8 @@ post:
   operationId: SaveGame
   description: |
     Saves the currently loaded session into the new save game file named as the argument. Requires Admin privileges. SaveName might be changed to satisfy file system restrictions on file names. Function does not return any data on success.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/setAdminPassword/setAdminPassword.yml
+++ b/openapi/functions/setAdminPassword/setAdminPassword.yml
@@ -3,6 +3,8 @@ post:
   operationId: SetAdminPassword
   description: |
     Updates the currently set Admin Password. This will invalidate all previously issued Client and Admin authentication tokens. Requires Admin privileges. Function does not return any data on success.
+  tags:
+  - Authorization
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
+++ b/openapi/functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
@@ -3,6 +3,8 @@ post:
   operationId: SetAutoLoadSessionName
   description: |
     Updates the name of the session that the Dedicated Server will automatically load on startup. Does not change currently loaded session. Requires Admin privileges. Function does not return any data on success.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
+++ b/openapi/functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
@@ -4,7 +4,8 @@ post:
   description: |
     Updates the name of the session that the Dedicated Server will automatically load on startup. Does not change currently loaded session. Requires Admin privileges. Function does not return any data on success.
   tags:
-  - Save Management
+  - Server
+  - Sessions
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/setClientPassword/setClientPassword.yml
+++ b/openapi/functions/setClientPassword/setClientPassword.yml
@@ -5,6 +5,7 @@ post:
     Updates the currently set Client Protection Password. This will invalidate all previously issued Client authentication tokens. Pass empty string to remove the password, and let anyone join the server as Client. Requres Admin privileges. Function does not return any data on success.
   tags:
   - Authorization
+  - Server
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/setClientPassword/setClientPassword.yml
+++ b/openapi/functions/setClientPassword/setClientPassword.yml
@@ -3,6 +3,8 @@ post:
   operationId: SetClientPassword
   description: |
     Updates the currently set Client Protection Password. This will invalidate all previously issued Client authentication tokens. Pass empty string to remove the password, and let anyone join the server as Client. Requres Admin privileges. Function does not return any data on success.
+  tags:
+  - Authorization
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/shutdown/shutdown.yml
+++ b/openapi/functions/shutdown/shutdown.yml
@@ -3,6 +3,8 @@ post:
   operationId: Shutdown
   description: |
     Shuts down the Dedicated Server. If automatic restart script is setup, this allows restarting the server to apply new settings or update. Requires Admin privileges. Shutdowns initiated by remote hosts are logged with their IP and their token. Function does not return any data on success, and does not take any parameters.
+  tags:
+  - Server Actions
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/shutdown/shutdown.yml
+++ b/openapi/functions/shutdown/shutdown.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Shuts down the Dedicated Server. If automatic restart script is setup, this allows restarting the server to apply new settings or update. Requires Admin privileges. Shutdowns initiated by remote hosts are logged with their IP and their token. Function does not return any data on success, and does not take any parameters.
   tags:
-  - Server Actions
+  - Server
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/uploadSaveGame/uploadSaveGame.yml
+++ b/openapi/functions/uploadSaveGame/uploadSaveGame.yml
@@ -3,6 +3,8 @@ post:
   operationId: UploadSaveGame
   description: |
     Shuts down the Dedicated Server. If automatic restart script is setup, this allows restarting the server to apply new settings or update. Requires Admin privileges. Shutdowns initiated by remote hosts are logged with their IP and their token. Function does not return any data on success, and does not take any parameters.
+  tags:
+  - Save Management
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/uploadSaveGame/uploadSaveGame.yml
+++ b/openapi/functions/uploadSaveGame/uploadSaveGame.yml
@@ -4,7 +4,7 @@ post:
   description: |
     Shuts down the Dedicated Server. If automatic restart script is setup, this allows restarting the server to apply new settings or update. Requires Admin privileges. Shutdowns initiated by remote hosts are logged with their IP and their token. Function does not return any data on success, and does not take any parameters.
   tags:
-  - Save Management
+  - Saves
   security:
   - bearerAuth: ['Administrator']
   requestBody:

--- a/openapi/functions/verifyAuthenticationToken/verifyAuthenticationToken.yml
+++ b/openapi/functions/verifyAuthenticationToken/verifyAuthenticationToken.yml
@@ -2,6 +2,8 @@ post:
   summary: Verify Authentication Token
   operationId: VerifyAuthenticationToken
   description: Verifies the Authentication token provided to the Dedicated Server API. Returns No Content if the provided token is valid. This function does not require input parameters and does not return any data.
+  tags:
+  - Authorization
   security:
   - bearerAuth: []
   requestBody:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -22,16 +22,14 @@ tags:
   description: Authorization
 - name: Authorization
   description: Authorization
-- name: Server Status
+- name: Server
   description: Server Status
-- name: Server Actions
-  description: Save Management
-- name: Server Options
-  description: Server Options
-- name: Game Settings
+- name: Game
   description: Game Settings
-- name: Save Management
-  description: Save Management
+- name: Saves
+  description: Saves
+- name: Sessions
+  description: Sessions
 paths:
 
   # --- Setup
@@ -66,37 +64,18 @@ paths:
   '/api/v1/?function=VerifyAuthenticationToken':
     $ref: functions/verifyAuthenticationToken/verifyAuthenticationToken.yml
 
-  # --- Server Status
+  # --- Sessions
+  # - Placed here to keep a specific ordering in our generated documentation
+
+  # EnumerateSessions
+  '/api/v1/?function=EnumerateSessions':
+    $ref: functions/enumerateSessions/enumerateSessions.yml
+
+  # --- Server
 
   # HealthCheck
   '/api/v1/?function=HealthCheck':
     $ref: functions/healthCheck/healthCheck.yml
-
-  # QueryServerState
-  '/api/v1/?function=QueryServerState':
-    $ref: functions/queryServerState/queryServerState.yml
-
-  # --- Game Settings
-
-  # GetAdvancedGameSettings
-  '/api/v1/?function=GetAdvancedGameSettings':
-    $ref: functions/getAdvancedGameSettings/getAdvancedGameSettings.yml
-
-  # ApplyAdvancedGameSettings
-  '/api/v1/?function=ApplyAdvancedGameSettings':
-    $ref: functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
-
-  # --- Server Actions
-
-  # RunCommand
-  '/api/v1/?function=RunCommand':
-    $ref: functions/runCommand/runCommand.yml
-
-  # Shutdown
-  '/api/v1/?function=Shutdown':
-    $ref: functions/shutdown/shutdown.yml
-
-  # --- Server Options
 
   # GetServerOptions
   '/api/v1/?function=GetServerOptions':
@@ -106,40 +85,61 @@ paths:
   '/api/v1/?function=ApplyServerOptions':
     $ref: functions/applyServerOptions/applyServerOptions.yml
 
-  # RenameServer
-  '/api/v1/?function=RenameServer':
-    $ref: functions/renameServer/renameServer.yml
-
-  # --- Save Management
-
   # SetAutoLoadSessionName
   '/api/v1/?function=SetAutoLoadSessionName':
     $ref: functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
 
-  # SaveGame
-  '/api/v1/?function=SaveGame':
-    $ref: functions/saveGame/saveGame.yml
+  # QueryServerState
+  '/api/v1/?function=QueryServerState':
+    $ref: functions/queryServerState/queryServerState.yml
 
-  # DeleteSaveFile
-  '/api/v1/?function=DeleteSaveFile':
-    $ref: functions/deleteSaveFile/deleteSaveFile.yml
+  # RenameServer
+  '/api/v1/?function=RenameServer':
+    $ref: functions/renameServer/renameServer.yml
+
+  # RunCommand
+  '/api/v1/?function=RunCommand':
+    $ref: functions/runCommand/runCommand.yml
+
+  # Shutdown
+  '/api/v1/?function=Shutdown':
+    $ref: functions/shutdown/shutdown.yml
+
+  # --- Sessions
+  # - Placed here to keep a specific ordering in our generated documentation
 
   # DeleteSaveSession
   '/api/v1/?function=DeleteSaveSession':
     $ref: functions/deleteSaveSession/deleteSaveSession.yml
 
-  # EnumerateSessions
-  '/api/v1/?function=EnumerateSessions':
-    $ref: functions/enumerateSessions/enumerateSessions.yml
+  # --- Game
 
-  # LoadGame
-  '/api/v1/?function=LoadGame':
-    $ref: functions/loadGame/loadGame.yml
+  # GetAdvancedGameSettings
+  '/api/v1/?function=GetAdvancedGameSettings':
+    $ref: functions/getAdvancedGameSettings/getAdvancedGameSettings.yml
+
+  # ApplyAdvancedGameSettings
+  '/api/v1/?function=ApplyAdvancedGameSettings':
+    $ref: functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
+
+  # --- Saves
+
+  # SaveGame
+  '/api/v1/?function=SaveGame':
+    $ref: functions/saveGame/saveGame.yml
+
+  # DownloadSaveGame
+  '/api/v1/?function=DownloadSaveGame':
+    $ref: functions/downloadSaveGame/downloadSaveGame.yml
 
   # UploadSaveGame
   '/api/v1/?function=UploadSaveGame':
     $ref: functions/uploadSaveGame/uploadSaveGame.yml
 
-  # DownloadSaveGame
-  '/api/v1/?function=DownloadSaveGame':
-    $ref: functions/downloadSaveGame/downloadSaveGame.yml
+  # LoadGame
+  '/api/v1/?function=LoadGame':
+    $ref: functions/loadGame/loadGame.yml
+
+  # DeleteSaveFile
+  '/api/v1/?function=DeleteSaveFile':
+    $ref: functions/deleteSaveFile/deleteSaveFile.yml

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -17,14 +17,34 @@ components:
       scheme: bearer
       bearerFormat: JWT
 
+tags:
+- name: Setup
+  description: Authorization
+- name: Authorization
+  description: Authorization
+- name: Server Status
+  description: Server Status
+- name: Server Actions
+  description: Save Management
+- name: Server Options
+  description: Server Options
+- name: Game Settings
+  description: Game Settings
+- name: Save Management
+  description: Save Management
 paths:
-  # HealthCheck
-  '/api/v1/?function=HealthCheck':
-    $ref: functions/healthCheck/healthCheck.yml
 
-  # VerifyAuthenticationToken
-  '/api/v1/?function=VerifyAuthenticationToken':
-    $ref: functions/verifyAuthenticationToken/verifyAuthenticationToken.yml
+  # --- Setup
+
+  # ClaimServer
+  '/api/v1/?function=ClaimServer':
+    $ref: functions/claimServer/claimServer.yml
+
+  # CreateNewGame
+  '/api/v1/?function=CreateNewGame':
+    $ref: functions/createNewGame/createNewGame.yml
+
+  # --- Authorization
 
   # PasswordlessLogin
   '/api/v1/?function=PasswordlessLogin':
@@ -34,13 +54,29 @@ paths:
   '/api/v1/?function=PasswordLogin':
     $ref: functions/passwordLogin/passwordLogin.yml
 
+  # SetClientPassword
+  '/api/v1/?function=SetClientPassword':
+    $ref: functions/setClientPassword/setClientPassword.yml
+
+  # SetAdminPassword
+  '/api/v1/?function=SetAdminPassword':
+    $ref: functions/setAdminPassword/setAdminPassword.yml
+
+  # VerifyAuthenticationToken
+  '/api/v1/?function=VerifyAuthenticationToken':
+    $ref: functions/verifyAuthenticationToken/verifyAuthenticationToken.yml
+
+  # --- Server Status
+
+  # HealthCheck
+  '/api/v1/?function=HealthCheck':
+    $ref: functions/healthCheck/healthCheck.yml
+
   # QueryServerState
   '/api/v1/?function=QueryServerState':
     $ref: functions/queryServerState/queryServerState.yml
 
-  # GetServerOptions
-  '/api/v1/?function=GetServerOptions':
-    $ref: functions/getServerOptions/getServerOptions.yml
+  # --- Game Settings
 
   # GetAdvancedGameSettings
   '/api/v1/?function=GetAdvancedGameSettings':
@@ -50,25 +86,7 @@ paths:
   '/api/v1/?function=ApplyAdvancedGameSettings':
     $ref: functions/applyAdvancedGameSettings/applyAdvancedGameSettings.yml
 
-  # ClaimServer
-  '/api/v1/?function=ClaimServer':
-    $ref: functions/claimServer/claimServer.yml
-
-  # RenameServer
-  '/api/v1/?function=RenameServer':
-    $ref: functions/renameServer/renameServer.yml
-
-  # SetClientPassword
-  '/api/v1/?function=SetClientPassword':
-    $ref: functions/setClientPassword/setClientPassword.yml
-
-  # SetAdminPassword
-  '/api/v1/?function=SetAdminPassword':
-    $ref: functions/setAdminPassword/setAdminPassword.yml
-
-  # SetAutoLoadSessionName
-  '/api/v1/?function=SetAutoLoadSessionName':
-    $ref: functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
+  # --- Server Actions
 
   # RunCommand
   '/api/v1/?function=RunCommand':
@@ -78,13 +96,25 @@ paths:
   '/api/v1/?function=Shutdown':
     $ref: functions/shutdown/shutdown.yml
 
+  # --- Server Options
+
+  # GetServerOptions
+  '/api/v1/?function=GetServerOptions':
+    $ref: functions/getServerOptions/getServerOptions.yml
+
   # ApplyServerOptions
   '/api/v1/?function=ApplyServerOptions':
     $ref: functions/applyServerOptions/applyServerOptions.yml
 
-  # CreateNewGame
-  '/api/v1/?function=CreateNewGame':
-    $ref: functions/createNewGame/createNewGame.yml
+  # RenameServer
+  '/api/v1/?function=RenameServer':
+    $ref: functions/renameServer/renameServer.yml
+
+  # --- Save Management
+
+  # SetAutoLoadSessionName
+  '/api/v1/?function=SetAutoLoadSessionName':
+    $ref: functions/setAutoLoadSessionName/setAutoLoadSessionName.yml
 
   # SaveGame
   '/api/v1/?function=SaveGame':

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -19,20 +19,20 @@ components:
 
 tags:
 - name: Setup
-  description: Authorization
+  description: Functions typically ran shortly after a Game Server starts up for the first time
 - name: Authorization
-  description: Authorization
+  description: Anything related to API or Server access
 - name: Server
-  description: Server Status
+  description: Anything related to managing or adjusting the Server
 - name: Game
-  description: Game Settings
+  description: Anything related to the game running on the Server
 - name: Saves
-  description: Saves
+  description: Individual Save related management
 - name: Sessions
-  description: Sessions
+  description: Save Sessions related management
 paths:
 
-  # --- Setup
+  # --- Initialization
 
   # ClaimServer
   '/api/v1/?function=ClaimServer':

--- a/redocly.yml
+++ b/redocly.yml
@@ -11,3 +11,6 @@ rules:
 theme:
   openapi:
     htmlTemplate: ./docs/index.html
+    jsonSampleExpandLevel: all
+    schemaExpansionLevel: all
+    sortOperationsAlphabetically: false


### PR DESCRIPTION
# Motivations
In preparation for better documentation all of the operations could be sorted into relevant tags

# Modifications
- Add tags for better visual documentation organization
- Expand all JSON samples by default
- Expand all schemas by default
- Stop sorting operations alphabetically